### PR TITLE
Provide default inputs for bindField and returnFields

### DIFF
--- a/GetRecordsInTextCollection.cls
+++ b/GetRecordsInTextCollection.cls
@@ -10,6 +10,12 @@ global with sharing class GetRecordsInTextCollection {
         validateInputs(inputs); // throw an error if there's an issue, otherwise continue
         
         for(FlowInput input : inputs){
+            // If no bind key is selected, use the default of 'id'
+            if (input.bindField == null) {
+                input.bindField = 'id';
+            }
+            input.bindField = input.bindField.toLowerCase();
+
             // add the valid field values for this input to a map of field name to a set of valid values
             if (!fieldNameToValidValues.containsKey(input.bindField)){
                 fieldNameToValidValues.put(input.bindField, new Set<String>());
@@ -26,7 +32,24 @@ global with sharing class GetRecordsInTextCollection {
             // add all the return fields to a set (in case different interviews request different fields)
             // note that we will return all fields for all the records. 
             // Most of the time, all the interviews will request the same fields. Even if not, the user is not likely to notice, and we don't anticipate performance issues.
-            allReturnFields.addAll(input.returnFields);
+
+            //if input.returnFields is null, return all accessible fields
+            if (input.returnFields != null) {
+                for (String field : input.returnFields) {
+                    allReturnFields.add(field.toLowerCase());
+                }
+            } else {
+                // If no fields were selected, add all accessible fields
+                Schema.SObjectType targetType = Schema.getGlobalDescribe()
+                    .get(input.objectName);
+                for (Schema.SObjectField field : targetType.getDescribe().fields.getMap().values()) {
+                    Schema.DescribeFieldResult dfr = field.getDescribe();
+                    if (dfr.isAccessible()) {
+                        allReturnFields.add(dfr.getName().toLowerCase());
+                    }
+                }
+            }
+
         }
         
         // build the soql

--- a/GetRecordsInTextCollectionTest.cls
+++ b/GetRecordsInTextCollectionTest.cls
@@ -37,6 +37,16 @@ private class GetRecordsInTextCollectionTest {
     }
     
     @IsTest
+    static void getRecords_AccountsByIdNoFields_Three() {
+        List <Account> accs = [SELECT Id FROM Account LIMIT 3];
+        List <String> validIds = new List <String> {accs[0].Id, accs[1].Id, accs[2].Id};
+        List <GetRecordsInTextCollection.FlowInput> inputList = prepSingleInputList('Account',null,validIds);
+        inputList[0].returnFields = null;
+        List <Account> accountList = GetRecordsInTextCollection.GetRecordsInTextCollection(inputList)[0].matchingRecords;
+        System.assertEquals(3, accountList.size(),'Should find 3 accounts matched on id');
+    }
+    
+    @IsTest
     static void getRecords_InvalidObject_ThrowError() {
         List<String> validTextCollection = new List <String> {'US','CA'};
         List <GetRecordsInTextCollection.FlowInput> inputList = prepSingleInputList('Nothing','No_Field__c',validTextCollection);


### PR DESCRIPTION
Add functionality to default `bindField` to `Id` and `returnFields` to all visible fields, when those inputs are not provided.